### PR TITLE
Safer butte v1

### DIFF
--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -476,26 +476,49 @@ impl ToTokens for Enum<'_> {
 
         // assign a value to the key if one was given, otherwise give it the
         // enumerated index's value
-        let fields = values
-            .iter()
-            .enumerate()
-            .map(|(i, EnumVal { id: key, value })| {
-                // format the value with the correct type, i.e., base_type
-                let scalar_value = lit_int(
-                    if let Some(constant) = *value {
-                        constant
-                    } else {
-                        i.try_into().expect("invalid conversion to enum base type")
-                    },
-                    base_type.to_token_stream(),
-                );
-                quote! {
-                    #key = #scalar_value
-                }
-            });
+        let variants_and_scalars =
+            values
+                .iter()
+                .enumerate()
+                .map(|(i, EnumVal { id: key, value })| {
+                    // format the value with the correct type, i.e., base_type
+                    let scalar_value = lit_int(
+                        if let Some(constant) = *value {
+                            constant
+                        } else {
+                            i.try_into().expect("invalid conversion to enum base type")
+                        },
+                        base_type.to_token_stream(),
+                    );
+                    (quote!(#key), quote!(#scalar_value))
+                });
 
         let raw_snake_enum_name = enum_id.raw.to_snake_case();
         let enum_id_fn_name = format_ident!("enum_name_{}", raw_snake_enum_name);
+
+        let from_base_to_enum_variants =
+            variants_and_scalars
+                .clone()
+                .map(|(variant_name, scalar_value)| {
+                    quote! {
+                        #scalar_value => Ok(<#enum_id>::#variant_name)
+                    }
+                });
+
+        let from_enum_variant_to_base =
+            variants_and_scalars
+                .clone()
+                .map(|(variant_name, scalar_value)| {
+                    quote! {
+                        <#enum_id>::#variant_name => #scalar_value
+                    }
+                });
+
+        let fields = variants_and_scalars.map(|(variant_name, scalar_value)| {
+            quote! {
+                #variant_name = #scalar_value
+            }
+        });
 
         // TODO: Maybe separate these pieces to avoid variables that used far
         // away from their definition.
@@ -513,23 +536,26 @@ impl ToTokens for Enum<'_> {
                 type Inner = Self;
 
                 fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, butte::Error> {
-                    butte::read_scalar_at::<Self>(buf, loc)
+                    let scalar = butte::read_scalar_at::<#base_type>(buf, loc)?;
+                    <Self as std::convert::TryFrom<#base_type>>::try_from(scalar)
                 }
             }
 
-            impl butte::EndianScalar for #enum_id {
-                #[inline]
-                fn to_little_endian(self) -> Self {
-                    let n = #base_type::to_le(self as #base_type);
-                    let p = &n as *const #base_type as *const Self;
-                    unsafe { *p }
+            impl std::convert::TryFrom<#base_type> for #enum_id {
+                type Error = butte::Error;
+                fn try_from(value: #base_type) -> Result<Self, Self::Error> {
+                    match value {
+                        #(#from_base_to_enum_variants),*,
+                        _ => Err(butte::Error::UnknownEnumVariant)
+                    }
                 }
+            }
 
-                #[inline]
-                fn from_little_endian(self) -> Self {
-                    let n = #base_type::from_le(self as #base_type);
-                    let p = &n as *const #base_type as *const Self;
-                    unsafe { *p }
+            impl From<#enum_id> for #base_type {
+                fn from(value: #enum_id) -> #base_type {
+                    match value {
+                        #(#from_enum_variant_to_base),*
+                    }
                 }
             }
 
@@ -538,7 +564,8 @@ impl ToTokens for Enum<'_> {
 
                 #[inline]
                 fn push(&self, dst: &mut [u8], _rest: &[u8]) {
-                    butte::emplace_scalar::<Self>(dst, *self);
+                    let scalar = <#base_type>::from(*self);
+                    butte::emplace_scalar::<#base_type>(dst, scalar);
                 }
             }
 

--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -209,9 +209,9 @@ impl ToTokens for Table<'_> {
 
             quote! {
                 #[inline]
-                pub fn #snake_name(&self) -> Option<#ty_simple_lifetime> {
+                pub fn #snake_name(&self) -> Result<Option<#ty_simple_lifetime>, butte::Error> {
                     self.table
-                        .get::<#ty_wrapped>(#struct_id::#offset_name, None)
+                        .get::<#ty_wrapped>(#struct_id::#offset_name)
                 }
             }
         });
@@ -265,9 +265,9 @@ impl ToTokens for Table<'_> {
                 type Inner = Self;
 
                 #[inline]
-                fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+                fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, butte::Error> {
                     let table = butte::Table { buf, loc };
-                    Self { table }
+                    Ok(Self { table })
                 }
             }
 
@@ -512,7 +512,7 @@ impl ToTokens for Enum<'_> {
             impl<'a> butte::Follow<'a> for #enum_id {
                 type Inner = Self;
 
-                fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+                fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, butte::Error> {
                     butte::read_scalar_at::<Self>(buf, loc)
                 }
             }

--- a/butte-examples/fbs/greeter/greeter.fbs
+++ b/butte-examples/fbs/greeter/greeter.fbs
@@ -16,10 +16,16 @@ table ManyHellosRequest {
 }
 
 namespace baz.buzz;
+
+table FooBar {
+  name: string;
+  my_foo: Foo;
+}
+
 enum Foo : int32 {
-  a,
-  b,
-  c
+  A,
+  B,
+  C
 }
 
 /// A greeter service!

--- a/butte-examples/src/greeter/greeter.rs
+++ b/butte-examples/src/greeter/greeter.rs
@@ -18,8 +18,26 @@ fn main() -> Result<()> {
     let dname = root.name()?;
     let expected = Some(raw_name);
     if dname != expected {
-        Err(anyhow!("Expected {:?}, got {:?}", expected, dname))
-    } else {
-        Ok(())
+        return Err(anyhow!("Expected {:?}, got {:?}", expected, dname));
     }
+
+    use greeter::baz::buzz::{Foo, FooBar, FooBarArgs};
+    let mut builder = fb::FlatBufferBuilder::new();
+    let raw_name = "A Name";
+    let name = builder.create_string(raw_name);
+    let args = FooBarArgs {
+        name,
+        my_foo: Foo::B,
+    };
+    let req = FooBar::create(&mut builder, &args);
+    builder.finish_minimal(req);
+    let raw_bytes = builder.finished_data();
+    let root = fb::get_root::<FooBar>(raw_bytes)?;
+    let dfoo = root.my_foo()?;
+    let expected = Some(Foo::B);
+    if dfoo != expected {
+        return Err(anyhow!("Expected {:?}, got {:?}", expected, dfoo));
+    }
+
+    Ok(())
 }

--- a/butte-examples/src/greeter/greeter.rs
+++ b/butte-examples/src/greeter/greeter.rs
@@ -14,8 +14,8 @@ fn main() -> Result<()> {
     let req = HelloRequest::create(&mut builder, &args);
     builder.finish_minimal(req);
     let raw_bytes = builder.finished_data();
-    let root = fb::get_root::<HelloRequest>(raw_bytes);
-    let dname = root.name();
+    let root = fb::get_root::<HelloRequest>(raw_bytes)?;
+    let dname = root.name()?;
     let expected = Some(raw_name);
     if dname != expected {
         Err(anyhow!("Expected {:?}, got {:?}", expected, dname))

--- a/butte/src/builder.rs
+++ b/butte/src/builder.rs
@@ -1,18 +1,19 @@
 /*
- * Copyright 2018 Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright 2018 Google Inc. All rights reserved.
+* Copyright 2019 Butte authors. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 extern crate smallvec;
 
@@ -351,7 +352,12 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
     ) {
         let idx = self.used_space() - tab_revloc.value() as usize;
         let tab = Table::new(&self.owned_buf[self.head..], idx);
-        let o = tab.vtable().get(slot_byte_loc) as usize;
+        let o = tab
+            .vtable()
+            .expect("Could not get VTable")
+            .get(slot_byte_loc)
+            .expect("Could not get byte loc")
+            .expect("No value at byte loc") as usize;
         assert!(o != 0, "missing required field {}", assert_msg_name);
     }
 
@@ -491,7 +497,7 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
 
         {
             let n = self.head + self.used_space() - object_revloc_to_vtable.value() as usize;
-            let saw = read_scalar_at::<UOffsetT>(&self.owned_buf, n);
+            let saw = read_scalar_at::<UOffsetT>(&self.owned_buf, n).expect("Buffer too small");
             debug_assert_eq!(saw, 0xF0F0_F0F0);
             emplace_scalar::<SOffsetT>(
                 &mut self.owned_buf[n..n + SIZE_SOFFSET],

--- a/butte/src/endian_scalar.rs
+++ b/butte/src/endian_scalar.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Google Inc. All rights reserved.
+ * Copyright 2019 Butte authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +15,7 @@
  * limitations under the License.
  */
 
+use crate::Error;
 use std::mem::size_of;
 
 /// Trait for values that must be stored in little-endian byte order, but
@@ -161,19 +163,19 @@ pub fn emplace_scalar<T: EndianScalar>(s: &mut [u8], x: T) {
 /// Read an EndianScalar from the provided byte slice at the specified location.
 /// Performs endian conversion, if necessary.
 #[inline]
-pub fn read_scalar_at<T: EndianScalar>(s: &[u8], loc: usize) -> T {
-    let buf = &s[loc..loc + size_of::<T>()];
+pub fn read_scalar_at<T: EndianScalar>(s: &[u8], loc: usize) -> Result<T, Error> {
+    let buf = &s.get(loc..loc + size_of::<T>()).ok_or(Error::OutOfBounds)?;
     read_scalar(buf)
 }
 
 /// Read an EndianScalar from the provided byte slice. Performs endian
 /// conversion, if necessary.
 #[inline]
-pub fn read_scalar<T: EndianScalar>(s: &[u8]) -> T {
+pub fn read_scalar<T: EndianScalar>(s: &[u8]) -> Result<T, Error> {
     let sz = size_of::<T>();
 
-    let p = (&s[..sz]).as_ptr() as *const T;
+    let p = (&s.get(..sz).ok_or(Error::OutOfBounds)?).as_ptr() as *const T;
     let x = unsafe { *p };
 
-    x.from_little_endian()
+    Ok(x.from_little_endian())
 }

--- a/butte/src/error.rs
+++ b/butte/src/error.rs
@@ -1,0 +1,24 @@
+use std::fmt;
+
+/// An error while accessing a flatbuffer
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    /// Returned if accessing the flatbuffer triggers an out-of-bounds access
+    OutOfBounds,
+    /// Returned if a string is not null-terminated,
+    NonNullTerminatedString,
+    // Returned if a buffer refers to an unknown union variant
+    UnknownUnionVariant,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::OutOfBounds => write!(f, "memory access is out of bounds"),
+            Error::NonNullTerminatedString => write!(f, "string is not terminated with null"),
+            Error::UnknownUnionVariant => write!(f, "unknown union variant"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/butte/src/error.rs
+++ b/butte/src/error.rs
@@ -5,6 +5,8 @@ use std::fmt;
 pub enum Error {
     /// Returned if accessing the flatbuffer triggers an out-of-bounds access
     OutOfBounds,
+    /// Returned if a string is not UTF8
+    NonUtf8String,
     /// Returned if a string is not null-terminated,
     NonNullTerminatedString,
     // Returned if a buffer refers to an unknown union variant
@@ -14,7 +16,8 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::OutOfBounds => write!(f, "memory access is out of bounds"),
+            Error::OutOfBounds => write!(f, "flatbuffer access is out of bounds"),
+            Error::NonUtf8String => write!(f, "string is not UTF8 encoded"),
             Error::NonNullTerminatedString => write!(f, "string is not terminated with null"),
             Error::UnknownUnionVariant => write!(f, "unknown union variant"),
         }

--- a/butte/src/error.rs
+++ b/butte/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     NonUtf8String,
     /// Returned if a string is not null-terminated,
     NonNullTerminatedString,
+    // Returned if a buffer refers to an unknown enum variant
+    UnknownEnumVariant,
     // Returned if a buffer refers to an unknown union variant
     UnknownUnionVariant,
 }
@@ -19,6 +21,7 @@ impl fmt::Display for Error {
             Error::OutOfBounds => write!(f, "flatbuffer access is out of bounds"),
             Error::NonUtf8String => write!(f, "string is not UTF8 encoded"),
             Error::NonNullTerminatedString => write!(f, "string is not terminated with null"),
+            Error::UnknownEnumVariant => write!(f, "unknown enum variant"),
             Error::UnknownUnionVariant => write!(f, "unknown union variant"),
         }
     }

--- a/butte/src/follow.rs
+++ b/butte/src/follow.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Google Inc. All rights reserved.
+ * Copyright 2019 Butte authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +15,7 @@
  * limitations under the License.
  */
 
+use crate::Error;
 use std::marker::PhantomData;
 
 /// Follow is a trait that allows us to access FlatBuffers in a declarative,
@@ -29,13 +31,13 @@ use std::marker::PhantomData;
 /// continue traversing the FlatBuffer.
 pub trait Follow<'a> {
     type Inner;
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner;
+    fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, Error>;
 }
 
 /// Execute a follow as a top-level function.
 #[allow(dead_code)]
 #[inline]
-pub fn lifted_follow<'a, T: Follow<'a>>(buf: &'a [u8], loc: usize) -> T::Inner {
+pub fn lifted_follow<'a, T: Follow<'a>>(buf: &'a [u8], loc: usize) -> Result<T::Inner, Error> {
     T::follow(buf, loc)
 }
 
@@ -49,14 +51,14 @@ impl<'a, T: Follow<'a> + 'a> FollowStart<T> {
         Self { 0: PhantomData }
     }
     #[inline]
-    pub fn self_follow(&'a self, buf: &'a [u8], loc: usize) -> T::Inner {
+    pub fn self_follow(&'a self, buf: &'a [u8], loc: usize) -> Result<T::Inner, Error> {
         T::follow(buf, loc)
     }
 }
 impl<'a, T: Follow<'a>> Follow<'a> for FollowStart<T> {
     type Inner = T::Inner;
     #[inline]
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, Error> {
         T::follow(buf, loc)
     }
 }

--- a/butte/src/lib.rs
+++ b/butte/src/lib.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Google Inc. All rights reserved.
+ * Copyright 2019 Butte authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +31,7 @@
 
 mod builder;
 mod endian_scalar;
+mod error;
 mod follow;
 mod primitives;
 mod push;
@@ -43,6 +45,7 @@ pub use crate::{
     endian_scalar::{
         byte_swap_f32, byte_swap_f64, emplace_scalar, read_scalar, read_scalar_at, EndianScalar,
     },
+    error::Error,
     follow::{Follow, FollowStart},
     primitives::*,
     push::Push,

--- a/butte/src/primitives.rs
+++ b/butte/src/primitives.rs
@@ -43,9 +43,9 @@ pub const SIZE_I64: usize = size_of::<i64>();
 pub const SIZE_F32: usize = size_of::<f32>();
 pub const SIZE_F64: usize = size_of::<f64>();
 
-pub const SIZE_SOFFSET: usize = SIZE_I32;
-pub const SIZE_UOFFSET: usize = SIZE_U32;
-pub const SIZE_VOFFSET: usize = SIZE_I16;
+pub const SIZE_SOFFSET: usize = size_of::<SOffsetT>();
+pub const SIZE_UOFFSET: usize = size_of::<UOffsetT>();
+pub const SIZE_VOFFSET: usize = size_of::<VOffsetT>();
 
 pub const SIZE_SIZEPREFIX: usize = SIZE_UOFFSET;
 
@@ -56,8 +56,8 @@ pub type SOffsetT = i32;
 /// and lengths of vectors.
 pub type UOffsetT = u32;
 
-/// VOffsetT is a i32 that is used by vtables to store field data.
-pub type VOffsetT = i16;
+/// VOffsetT is a u16 that is used by vtables to store field data.
+pub type VOffsetT = u16;
 
 /// TableFinishedWIPOffset marks a WIPOffset as being for a finished table.
 #[derive(Clone, Copy)]

--- a/butte/src/table.rs
+++ b/butte/src/table.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Google Inc. All rights reserved.
+ * Copyright 2019 Butte authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
  * limitations under the License.
  */
 
-use crate::{follow::Follow, primitives::*, vtable::VTable};
+use crate::{follow::Follow, primitives::*, vtable::VTable, Error};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Table<'a> {
@@ -28,48 +29,49 @@ impl<'a> Table<'a> {
         Table { buf, loc }
     }
     #[inline]
-    pub fn vtable(&self) -> VTable<'a> {
+    pub fn vtable(&self) -> Result<VTable<'a>, Error> {
         <BackwardsSOffset<VTable<'a>>>::follow(self.buf, self.loc)
     }
     #[inline]
     pub fn get<T: Follow<'a> + 'a>(
         &self,
         slot_byte_loc: VOffsetT,
-        default: Option<T::Inner>,
-    ) -> Option<T::Inner> {
-        let o = self.vtable().get(slot_byte_loc) as usize;
-        if o == 0 {
-            return default;
+    ) -> Result<Option<T::Inner>, Error> {
+        let v_offset = self.vtable()?.get(slot_byte_loc)?;
+        if let Some(v_offset) = v_offset {
+            let o = v_offset as usize;
+            <T>::follow(self.buf, self.loc + o).map(Some)
+        } else {
+            Ok(None)
         }
-        Some(<T>::follow(self.buf, self.loc + o))
     }
 }
 
 impl<'a> Follow<'a> for Table<'a> {
     type Inner = Table<'a>;
     #[inline]
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Table { buf, loc }
+    fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, Error> {
+        Ok(Table { buf, loc })
     }
 }
 
 #[inline]
-pub fn get_root<'a, T: Follow<'a> + 'a>(data: &'a [u8]) -> T::Inner {
+pub fn get_root<'a, T: Follow<'a> + 'a>(data: &'a [u8]) -> Result<T::Inner, Error> {
     <ForwardsUOffset<T>>::follow(data, 0)
 }
 #[inline]
-pub fn get_size_prefixed_root<'a, T: Follow<'a> + 'a>(data: &'a [u8]) -> T::Inner {
+pub fn get_size_prefixed_root<'a, T: Follow<'a> + 'a>(data: &'a [u8]) -> Result<T::Inner, Error> {
     <SkipSizePrefix<ForwardsUOffset<T>>>::follow(data, 0)
 }
 #[inline]
-pub fn buffer_has_identifier(data: &[u8], ident: &str, size_prefixed: bool) -> bool {
+pub fn buffer_has_identifier(data: &[u8], ident: &str, size_prefixed: bool) -> Result<bool, Error> {
     assert_eq!(ident.len(), FILE_IDENTIFIER_LENGTH);
 
     let got = if size_prefixed {
-        <SkipSizePrefix<SkipRootOffset<FileIdentifier>>>::follow(data, 0)
+        <SkipSizePrefix<SkipRootOffset<FileIdentifier>>>::follow(data, 0)?
     } else {
-        <SkipRootOffset<FileIdentifier>>::follow(data, 0)
+        <SkipRootOffset<FileIdentifier>>::follow(data, 0)?
     };
 
-    ident.as_bytes() == got
+    Ok(ident.as_bytes() == got)
 }

--- a/butte/src/vector.rs
+++ b/butte/src/vector.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Google Inc. All rights reserved.
+ * Copyright 2019 Butte authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +22,8 @@ use std::{
     slice::from_raw_parts,
     str::from_utf8_unchecked,
 };
+
+use crate::Error;
 
 #[cfg(target_endian = "little")]
 use crate::endian_scalar::EndianScalar;
@@ -50,19 +53,19 @@ impl<'a, T: 'a> Vector<'a, T> {
     }
 
     #[inline(always)]
-    pub fn len(&self) -> usize {
-        read_scalar_at::<UOffsetT>(&self.0, self.1) as usize
+    pub fn len(&self) -> Result<usize, Error> {
+        Ok(read_scalar_at::<UOffsetT>(&self.0, self.1)? as usize)
     }
     #[inline(always)]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    pub fn is_empty(&self) -> Result<bool, Error> {
+        Ok(self.len()? == 0)
     }
 }
 
 impl<'a, T: Follow<'a> + 'a> Vector<'a, T> {
     #[inline(always)]
-    pub fn get(&self, idx: usize) -> T::Inner {
-        debug_assert!(idx < read_scalar_at::<u32>(&self.0, self.1) as usize);
+    pub fn get(&self, idx: usize) -> Result<T::Inner, Error> {
+        debug_assert!(idx < read_scalar_at::<u32>(&self.0, self.1)? as usize);
         let sz = size_of::<T>();
         debug_assert!(sz > 0);
         T::follow(self.0, self.1 as usize + SIZE_UOFFSET + sz * idx)
@@ -70,22 +73,27 @@ impl<'a, T: Follow<'a> + 'a> Vector<'a, T> {
 
     #[inline(always)]
     pub fn iter(&self) -> VectorIter<'a, T> {
-        VectorIter::new(*self)
+        // This method cannot fail -- we return a len of 0 (an empty iterator)
+        // if reading len() returns an error.
+        let len = self.len().unwrap_or(0);
+        VectorIter::new(*self, len)
     }
 }
 
 pub trait SafeSliceAccess {}
 impl<'a, T: SafeSliceAccess + 'a> Vector<'a, T> {
-    pub fn safe_slice(self) -> &'a [T] {
+    pub fn safe_slice(self) -> Result<&'a [T], Error> {
         let buf = self.0;
         let loc = self.1;
         let sz = size_of::<T>();
         debug_assert!(sz > 0);
-        let len = read_scalar_at::<UOffsetT>(&buf, loc) as usize;
-        let data_buf = &buf[loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len * sz];
+        let len = read_scalar_at::<UOffsetT>(&buf, loc)? as usize;
+        let data_buf = buf
+            .get(loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len * sz)
+            .ok_or(Error::OutOfBounds)?;
         let ptr = data_buf.as_ptr() as *const T;
         let s: &'a [T] = unsafe { from_raw_parts(ptr, len) };
-        s
+        Ok(s)
     }
 }
 
@@ -110,38 +118,43 @@ mod le_safe_slice_impls {
 #[cfg(target_endian = "little")]
 pub use self::le_safe_slice_impls::*;
 
-pub fn follow_cast_ref<'a, T: Sized + 'a>(buf: &'a [u8], loc: usize) -> &'a T {
+pub fn follow_cast_ref<'a, T: Sized + 'a>(buf: &'a [u8], loc: usize) -> Result<&'a T, Error> {
     let sz = size_of::<T>();
-    let buf = &buf[loc..loc + sz];
+    let buf = buf.get(loc..loc + sz).ok_or(Error::OutOfBounds)?;
     let ptr = buf.as_ptr() as *const T;
-    unsafe { &*ptr }
+    // magnet: is this safe for any T: Sized? I believe we'd need an extra bound with the required invariants.
+    Ok(unsafe { &*ptr })
 }
 
 impl<'a> Follow<'a> for &'a str {
     type Inner = &'a str;
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let len = read_scalar_at::<UOffsetT>(&buf, loc) as usize;
-        let slice = &buf[loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len];
-        unsafe { from_utf8_unchecked(slice) }
+    fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, Error> {
+        let len = read_scalar_at::<UOffsetT>(&buf, loc)? as usize;
+        let slice = buf
+            .get(loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len)
+            .ok_or(Error::OutOfBounds)?;
+        Ok(unsafe { from_utf8_unchecked(slice) })
     }
 }
 
 #[cfg(target_endian = "little")]
-fn follow_slice_helper<T>(buf: &[u8], loc: usize) -> &[T] {
+fn follow_slice_helper<T>(buf: &[u8], loc: usize) -> Result<&[T], Error> {
     let sz = size_of::<T>();
     debug_assert!(sz > 0);
-    let len = read_scalar_at::<UOffsetT>(&buf, loc) as usize;
-    let data_buf = &buf[loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len * sz];
+    let len = read_scalar_at::<UOffsetT>(&buf, loc)? as usize;
+    let data_buf = buf
+        .get(loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len * sz)
+        .ok_or(Error::OutOfBounds)?;
     let ptr = data_buf.as_ptr() as *const T;
     let s: &[T] = unsafe { from_raw_parts(ptr, len) };
-    s
+    Ok(s)
 }
 
 /// Implement direct slice access if the host is little-endian.
 #[cfg(target_endian = "little")]
 impl<'a, T: EndianScalar> Follow<'a> for &'a [T] {
     type Inner = &'a [T];
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, Error> {
         follow_slice_helper::<T>(buf, loc)
     }
 }
@@ -149,8 +162,8 @@ impl<'a, T: EndianScalar> Follow<'a> for &'a [T] {
 /// Implement Follow for all possible Vectors that have Follow-able elements.
 impl<'a, T: Follow<'a> + 'a> Follow<'a> for Vector<'a, T> {
     type Inner = Vector<'a, T>;
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Vector::new(buf, loc)
+    fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, Error> {
+        Ok(Vector::new(buf, loc))
     }
 }
 
@@ -164,14 +177,14 @@ pub struct VectorIter<'a, T: 'a> {
 
 impl<'a, T: 'a> VectorIter<'a, T> {
     #[inline]
-    pub fn new(inner: Vector<'a, T>) -> Self {
+    pub fn new(inner: Vector<'a, T>, len: usize) -> Self {
         VectorIter {
             buf: inner.0,
             // inner.1 is the location of the data for the vector.
             // The first SIZE_UOFFSET bytes is the length. We skip
             // that to get to the actual vector content.
             loc: inner.1 + SIZE_UOFFSET,
-            remaining: inner.len(),
+            remaining: len,
             phantom: PhantomData,
         }
     }
@@ -190,10 +203,10 @@ impl<'a, T: Follow<'a> + 'a> Clone for VectorIter<'a, T> {
 }
 
 impl<'a, T: Follow<'a> + 'a> Iterator for VectorIter<'a, T> {
-    type Item = T::Inner;
+    type Item = Result<T::Inner, Error>;
 
     #[inline]
-    fn next(&mut self) -> Option<T::Inner> {
+    fn next(&mut self) -> Option<Self::Item> {
         let sz = size_of::<T>();
         debug_assert!(sz > 0);
 
@@ -208,7 +221,7 @@ impl<'a, T: Follow<'a> + 'a> Iterator for VectorIter<'a, T> {
     }
 
     #[inline]
-    fn nth(&mut self, n: usize) -> Option<T::Inner> {
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let sz = size_of::<T>();
         debug_assert!(sz > 0);
 
@@ -229,7 +242,7 @@ impl<'a, T: Follow<'a> + 'a> Iterator for VectorIter<'a, T> {
 
 impl<'a, T: Follow<'a> + 'a> DoubleEndedIterator for VectorIter<'a, T> {
     #[inline]
-    fn next_back(&mut self) -> Option<T::Inner> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         let sz = size_of::<T>();
         debug_assert!(sz > 0);
 
@@ -242,7 +255,7 @@ impl<'a, T: Follow<'a> + 'a> DoubleEndedIterator for VectorIter<'a, T> {
     }
 
     #[inline]
-    fn nth_back(&mut self, n: usize) -> Option<T::Inner> {
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         self.remaining = self.remaining.saturating_sub(n);
         self.next_back()
     }
@@ -258,7 +271,7 @@ impl<'a, T: 'a + Follow<'a>> ExactSizeIterator for VectorIter<'a, T> {
 impl<'a, T: 'a + Follow<'a>> FusedIterator for VectorIter<'a, T> {}
 
 impl<'a, T: Follow<'a> + 'a> IntoIterator for Vector<'a, T> {
-    type Item = T::Inner;
+    type Item = Result<T::Inner, Error>;
     type IntoIter = VectorIter<'a, T>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -267,7 +280,7 @@ impl<'a, T: Follow<'a> + 'a> IntoIterator for Vector<'a, T> {
 }
 
 impl<'a, 'b, T: Follow<'a> + 'a> IntoIterator for &'b Vector<'a, T> {
-    type Item = T::Inner;
+    type Item = Result<T::Inner, Error>;
     type IntoIter = VectorIter<'a, T>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/butte/src/vtable_writer.rs
+++ b/butte/src/vtable_writer.rs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Google Inc. All rights reserved.
+ * Copyright 2019 Butte authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +60,7 @@ impl<'a> VTableWriter<'a> {
     #[inline(always)]
     pub fn get_field_offset(&self, vtable_offset: VOffsetT) -> VOffsetT {
         let idx = vtable_offset as usize;
-        read_scalar_at::<VOffsetT>(&self.buf, idx)
+        read_scalar_at::<VOffsetT>(&self.buf, idx).expect("Could not read scalar")
     }
 
     /// Writes an object field offset into the vtable.


### PR DESCRIPTION
This PR aims to make working with untrusted flatbuffers safer and panic-free. 

- by returning an out-of-bounds error whenever we may read a flatbuffer that refers to an element out of the current buffer (previously this panicked)
- by not blindly converting flatbuffers String into &str without checking they're UTF8.  Instead, we perform the utf8 check and return the error if the String was not utf8. Users who want to avoid paying for the check should be able to define their String types as `&[u8]`, which maps to the flatbuffers Strings. (previously, this was undefined behavior)
- by not casting scalar references to enums references, which is also UB if the enum does not have a variant for each element in the scalar.  Instead, we generate safe, faillible conversions, and report the error back if the buffer contained an unknown enum variant.  (previously this was undefined behavior)

The builder API is left unchanged, as it should not deal with untrusted sources.

