### PR TITLE
Generate companion enum for unions in a separate `butte_gen` namespace

### DIFF
--- a/butte-examples/src/greeter/greeter.rs
+++ b/butte-examples/src/greeter/greeter.rs
@@ -7,8 +7,8 @@ pub mod greeter {
 
 fn main() -> Result<()> {
     use greeter::foo::bar::{
-        EitherHello, EitherHelloRequest, EitherHelloRequestArgs, EitherHelloType, HelloReply,
-        HelloReplyArgs, HelloRequest, HelloRequestArgs,
+        butte_gen::EitherHelloType, EitherHello, EitherHelloRequest, EitherHelloRequestArgs,
+        HelloReply, HelloReplyArgs, HelloRequest, HelloRequestArgs,
     };
     let mut builder = fb::FlatBufferBuilder::new();
     let name = builder.create_string("John");


### PR DESCRIPTION
Another namespace is used to avoid potential name clashes with the generated enum and another type, e.g, if a same namespace has an union named `Result`, the companion enum was generated as `ResultType`, which may clash as an existing type.  This commit puts `ResultType` in the `butte_gen` namespace, avoiding risks of clash.

This commits fixes namespace stacking and introduces facility to compute the relative path from an absolute path for a given location.

With this commit, it becomes trivial to generate namespaces and have different types refer to each other.  Proper `include` support is from reaching distance if anyone wants to give it a go :).