### PR TITLE
Rename sum type values to variants

### DIFF
--- a/butte-build/src/ast/parser.rs
+++ b/butte-build/src/ast/parser.rs
@@ -678,7 +678,7 @@ attribute a;";
     }
 }
 
-pub fn enum_body(input: &str) -> IResult<&str, Vec<EnumVal>> {
+pub fn enum_body(input: &str) -> IResult<&str, Vec<EnumVariant>> {
     delimited(
         delimited(comment_or_space0, left_brace, comment_or_space0),
         terminated(
@@ -703,12 +703,12 @@ pub fn enum_decl(input: &str) -> IResult<&str, Enum> {
         metadata,
         enum_body,
     ));
-    map(parser, |(comment, name, base_type, metadata, values)| {
+    map(parser, |(comment, name, base_type, metadata, variants)| {
         Enum::builder()
             .doc(comment)
             .id(name)
             .base_type(base_type)
-            .values(values)
+            .variants(variants)
             .metadata(metadata)
             .build()
     })(input)
@@ -790,11 +790,11 @@ pub fn union_decl(input: &str) -> IResult<&str, Union> {
         metadata,
         enum_body,
     ));
-    map(parser, |(comment, name, metadata, values)| {
+    map(parser, |(comment, name, metadata, variants)| {
         Union::builder()
             .doc(comment)
             .id(name)
-            .values(values)
+            .variants(variants)
             .metadata(metadata)
             .build()
     })(input)
@@ -1307,7 +1307,7 @@ pub fn type_(input: &str) -> IResult<&str, Type> {
 }
 
 /// Parse the individual items of an enum or union.
-pub fn enumval_decl(input: &str) -> IResult<&str, EnumVal> {
+pub fn enumval_decl(input: &str) -> IResult<&str, EnumVariant> {
     let parser = tuple((
         doc_comment,
         ident,
@@ -1317,7 +1317,11 @@ pub fn enumval_decl(input: &str) -> IResult<&str, EnumVal> {
         )),
     ));
     map(parser, |(comment, id, value)| {
-        EnumVal::builder().id(id).value(value).doc(comment).build()
+        EnumVariant::builder()
+            .id(id)
+            .value(value)
+            .doc(comment)
+            .build()
     })(input)
 }
 

--- a/butte-build/src/ast/parser_macros.rs
+++ b/butte-build/src/ast/parser_macros.rs
@@ -373,11 +373,11 @@ macro_rules! schema {
 
 #[macro_export]
 macro_rules! enum_ {
-    ($name:ident, $base_ty:ident, [ $($value:expr),+ ]$(, [ $($doc:literal),+ ])?) => {
+    ($name:ident, $base_ty:ident, [ $($variant:expr),+ ]$(, [ $($doc:literal),+ ])?) => {
         $crate::ast::types::Enum::builder()
             .id($crate::ast::types::Ident::from(stringify!($name)))
             .base_type($crate::ast::types::Type::$base_ty)
-            .values(vec![ $($value),+ ])
+            .variants(vec![ $($variant),+ ])
             .doc(vec![ $($($doc,)*)? ].into())
             .build()
     };
@@ -386,14 +386,14 @@ macro_rules! enum_ {
 #[macro_export]
 macro_rules! e_item {
     ($key:ident = $value:expr$(,[ $($doc:literal),+ ])?) => {
-        $crate::ast::types::EnumVal::builder()
+        $crate::ast::types::EnumVariant::builder()
             .id($crate::ast::types::Ident::from(stringify!($key)))
             .value(Some(($value).into()))
             .doc(vec![ $($($doc,)*)? ].into())
             .build()
     };
     ($key:ident$(, [ $($doc:literal),+ ])?) => {
-        $crate::ast::types::EnumVal::builder()
+        $crate::ast::types::EnumVariant::builder()
             .id($crate::ast::types::Ident::from(stringify!($key)))
             .doc(vec![ $($($doc,)*)? ].into())
             .build()
@@ -402,10 +402,10 @@ macro_rules! e_item {
 
 #[macro_export]
 macro_rules! union {
-    ($name:ident, [ $($value:expr),+ ]$(,[ $($doc:literal),+ ])?) => {
+    ($name:ident, [ $($variant:expr),+ ]$(,[ $($doc:literal),+ ])?) => {
         $crate::ast::types::Union::builder()
             .id($crate::ast::types::Ident::from(stringify!($name)))
-            .values(vec![ $($value),+ ])
+            .variants(vec![ $($variant),+ ])
             .doc(vec![ $($($doc,)*)? ].into())
             .build()
     };

--- a/butte-build/src/ast/types.rs
+++ b/butte-build/src/ast/types.rs
@@ -155,7 +155,7 @@ pub struct Table<'a> {
 #[derive(Debug, Clone, PartialEq, TypedBuilder)]
 pub struct Enum<'a> {
     pub id: Ident<'a>,
-    pub values: Vec<EnumVal<'a>>,
+    pub variants: Vec<EnumVariant<'a>>,
     pub base_type: Type<'a>,
 
     #[builder(default)]
@@ -169,7 +169,7 @@ pub struct Enum<'a> {
 #[derive(Debug, Clone, PartialEq, TypedBuilder)]
 pub struct Union<'a> {
     pub id: Ident<'a>,
-    pub values: Vec<EnumVal<'a>>,
+    pub variants: Vec<EnumVariant<'a>>,
 
     #[builder(default)]
     pub metadata: Option<Metadata<'a>>,
@@ -285,7 +285,7 @@ pub type BooleanConstant = bool;
 
 /// Type for `Enum`/`Union` values.
 #[derive(Debug, Clone, PartialEq, Hash, Eq, From, TypedBuilder)]
-pub struct EnumVal<'a> {
+pub struct EnumVariant<'a> {
     /// The name of the enum value.
     pub id: Ident<'a>,
 

--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -756,7 +756,7 @@ impl ToTokens for ir::Enum<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Self {
             ident: enum_id,
-            values,
+            variants,
             base_type,
             doc,
             ..
@@ -765,16 +765,16 @@ impl ToTokens for ir::Enum<'_> {
         let enum_id = enum_id.simple();
         // generate enum variant name => string name of the variant for use in
         // a match statement
-        let names_to_strings = values.iter().map(|ir::EnumVal { ident: key, .. }| {
+        let names_to_strings = variants.iter().map(|ir::EnumVariant { ident: key, .. }| {
             let raw_key = key.raw.as_ref();
             quote! {
                 #enum_id::#key => #raw_key
             }
         });
 
-        let default_value = values
+        let default_value = variants
             .iter()
-            .map(|ir::EnumVal { ident: key, .. }| {
+            .map(|ir::EnumVariant { ident: key, .. }| {
                 quote! {
                     #enum_id::#key
                 }
@@ -783,10 +783,10 @@ impl ToTokens for ir::Enum<'_> {
 
         // assign a value to the key if one was given, otherwise give it the
         // enumerated index's value
-        let variants_and_scalars = values.iter().enumerate().map(
+        let variants_and_scalars = variants.iter().enumerate().map(
             |(
                 i,
-                ir::EnumVal {
+                ir::EnumVariant {
                     ident: key,
                     value,
                     doc,

--- a/butte-build/src/ir/transform.rs
+++ b/butte-build/src/ir/transform.rs
@@ -242,10 +242,10 @@ impl<'a> Builder<'a> {
 
         let base_type = ir::EnumBaseType::try_from(&e.base_type)
             .map_err(|_| anyhow!("enum has bad base type: {}", ident))?;
-        let values: Vec<_> = e
-            .values
+        let variants: Vec<_> = e
+            .variants
             .iter()
-            .map(|v| ir::EnumVal {
+            .map(|v| ir::EnumVariant {
                 ident: ir::Ident::from(v.id),
                 value: v.value,
                 doc: v.doc.clone(),
@@ -257,7 +257,7 @@ impl<'a> Builder<'a> {
         self.types.insert(
             ident.clone(),
             CustomTypeStatus::Defined(ir::CustomType::Enum {
-                values: values.clone(),
+                variants: variants.clone(),
                 base_type,
             }),
         );
@@ -265,7 +265,7 @@ impl<'a> Builder<'a> {
         let s = ir::Enum {
             ident: ident.clone(),
             base_type,
-            values,
+            variants,
             doc,
         };
 
@@ -284,7 +284,7 @@ impl<'a> Builder<'a> {
         let mut variants = Vec::new();
 
         // Make sure all references to custom types are resolved
-        for f in &u.values {
+        for f in &u.variants {
             let ty = self.try_type(&ast::Type::Ident(ast::QualifiedIdent::from(vec![f.id])));
             if let Some(ty) = ty {
                 let id = &f.id;
@@ -339,12 +339,12 @@ impl<'a> Builder<'a> {
         // There's a max of 255 variants in a union in flatbuffers
         // See https://github.com/google/flatbuffers/issues/4209
         let base_type = ir::EnumBaseType::UByte;
-        let values: Vec<_> = std::iter::once(ir::EnumVal {
+        let variants: Vec<_> = std::iter::once(ir::EnumVariant {
             ident: ir::Ident::from("None"),
             value: Some(0.into()),
             doc: vec![].into(),
         })
-        .chain(u.values.iter().map(|v| ir::EnumVal {
+        .chain(u.variants.iter().map(|v| ir::EnumVariant {
             ident: v.id.into(),
             value: None,
             doc: v.doc.clone(),
@@ -356,7 +356,7 @@ impl<'a> Builder<'a> {
         self.types.insert(
             ident.clone(),
             CustomTypeStatus::Defined(ir::CustomType::Enum {
-                values: values.clone(),
+                variants: variants.clone(),
                 base_type,
             }),
         );
@@ -364,7 +364,7 @@ impl<'a> Builder<'a> {
         Ok(ir::Enum {
             ident: ident.clone(),
             base_type,
-            values,
+            variants,
             doc,
         })
     }
@@ -1102,9 +1102,13 @@ struct Vector3 {
                 ir::Enum::builder()
                     .ident(ir::QualifiedIdent::from("MyEnum"))
                     .base_type(ir::EnumBaseType::UByte)
-                    .values(vec![
-                        ir::EnumVal::builder().ident(ir::Ident::from("Foo")).build(),
-                        ir::EnumVal::builder().ident(ir::Ident::from("Bar")).build(),
+                    .variants(vec![
+                        ir::EnumVariant::builder()
+                            .ident(ir::Ident::from("Foo"))
+                            .build(),
+                        ir::EnumVariant::builder()
+                            .ident(ir::Ident::from("Bar"))
+                            .build(),
                     ])
                     .build(),
             )],
@@ -1138,13 +1142,17 @@ struct Vector3 {
                             ir::Enum::builder()
                                 .ident(ir::QualifiedIdent::parse_str("butte_gen.AorBType"))
                                 .base_type(ir::EnumBaseType::UByte)
-                                .values(vec![
-                                    ir::EnumVal::builder()
+                                .variants(vec![
+                                    ir::EnumVariant::builder()
                                         .ident(ir::Ident::from("None"))
                                         .value(Some(0.into()))
                                         .build(),
-                                    ir::EnumVal::builder().ident(ir::Ident::from("A")).build(),
-                                    ir::EnumVal::builder().ident(ir::Ident::from("B")).build(),
+                                    ir::EnumVariant::builder()
+                                        .ident(ir::Ident::from("A"))
+                                        .build(),
+                                    ir::EnumVariant::builder()
+                                        .ident(ir::Ident::from("B"))
+                                        .build(),
                                 ])
                                 .build(),
                         )])
@@ -1234,16 +1242,16 @@ struct Vector3 {
                             ir::Enum::builder()
                                 .ident(ir::QualifiedIdent::parse_str("butte_gen.AorBType"))
                                 .base_type(ir::EnumBaseType::UByte)
-                                .values(vec![
-                                    ir::EnumVal::builder()
+                                .variants(vec![
+                                    ir::EnumVariant::builder()
                                         .ident(ir::Ident::from("None"))
                                         .value(Some(0.into()))
                                         .build(),
-                                    ir::EnumVal::builder()
+                                    ir::EnumVariant::builder()
                                         .ident(ir::Ident::from("A"))
                                         .doc(vec![" Multiple", " lines", " of comments."].into())
                                         .build(),
-                                    ir::EnumVal::builder()
+                                    ir::EnumVariant::builder()
                                         .ident(ir::Ident::from("B"))
                                         .doc(vec![" Comments"].into())
                                         .build(),
@@ -1311,12 +1319,12 @@ struct Vector3 {
                                     ir::CustomTypeRef::builder()
                                         .ident(ir::QualifiedIdent::parse_str("butte_gen.AorBType"))
                                         .ty(ir::CustomType::Enum {
-                                            values: vec![
-                                                ir::EnumVal::builder()
+                                            variants: vec![
+                                                ir::EnumVariant::builder()
                                                     .ident(ir::Ident::from("None"))
                                                     .value(Some(0.into()))
                                                     .build(),
-                                                ir::EnumVal::builder()
+                                                ir::EnumVariant::builder()
                                                     .ident(ir::Ident::from("A"))
                                                     .doc(
                                                         vec![
@@ -1327,7 +1335,7 @@ struct Vector3 {
                                                         .into(),
                                                     )
                                                     .build(),
-                                                ir::EnumVal::builder()
+                                                ir::EnumVariant::builder()
                                                     .ident(ir::Ident::from("B"))
                                                     .doc(vec![" Comments"].into())
                                                     .build(),

--- a/butte-build/src/ir/types.rs
+++ b/butte-build/src/ir/types.rs
@@ -270,7 +270,7 @@ pub enum CustomType<'a> {
         fields: Vec<Field<'a>>,
     },
     Enum {
-        values: Vec<EnumVal<'a>>,
+        variants: Vec<EnumVariant<'a>>,
         base_type: EnumBaseType,
     },
     Union {
@@ -291,7 +291,7 @@ impl<'a> CustomType<'a> {
 #[derive(Debug, Clone, PartialEq, TypedBuilder)]
 pub struct Enum<'a> {
     pub ident: QualifiedIdent<'a>,
-    pub values: Vec<EnumVal<'a>>,
+    pub variants: Vec<EnumVariant<'a>>,
     pub base_type: EnumBaseType,
 
     #[builder(default)]
@@ -402,7 +402,7 @@ pub enum RpcStreaming {
 
 impl Default for RpcStreaming {
     fn default() -> Self {
-        RpcStreaming::None
+        Self::None
     }
 }
 
@@ -413,7 +413,7 @@ pub struct RootType<'a> {
 
 /// Type for `Enum` values.
 #[derive(Debug, Clone, PartialEq, Hash, Eq, From, TypedBuilder)]
-pub struct EnumVal<'a> {
+pub struct EnumVariant<'a> {
     /// The name of the enum value.
     pub ident: Ident<'a>,
 


### PR DESCRIPTION
This PR renames what was previously called `values` to variants in sum types
(`enum` and `union`).