### PR TITLE
Fix: array of tables

### DIFF
--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -157,8 +157,13 @@ fn to_type_token(
         }
         ir::Type::Array(ty) => {
             // Arrays wrap the wrapping tokens with Vector
-            let component_token =
-                to_type_token(context_namespace, ty, lifetime, wrap_refs_types, true);
+            let component_token = to_type_token(
+                context_namespace,
+                ty,
+                lifetime,
+                &quote!(butte::ForwardsUOffset),
+                true,
+            );
             let ty = quote!(butte::Vector<#lifetime, #component_token>);
 
             let wrap_tokens = wrap_refs_types.into_token_stream();

--- a/butte-examples/build.rs
+++ b/butte-examples/build.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    butte_build::compile_fbs("fbs/greeter/greeter.fbs")
+    for fbs in &["fbs/array.fbs", "fbs/greeter/greeter.fbs"] {
+        butte_build::compile_fbs(fbs)?;
+    }
+    Ok(())
 }

--- a/butte-examples/fbs/array.fbs
+++ b/butte-examples/fbs/array.fbs
@@ -1,0 +1,24 @@
+/// Flatbuffers namespaces are defined as UpperCamelCase.
+namespace Array;
+
+/// A test entry with a value.
+table Entry {
+  value: uint64;
+}
+
+enum Value: ubyte {
+  A = 0,
+  B = 1
+}
+
+/// Different arrays.
+table ArrayTable {
+  table_entries: [Entry];
+  enum_entries: [Value];
+  int_entries: [int32];
+}
+
+/// Array of arrays.
+table ArrayOfArrayTable {
+  table_arrays: [[Entry]] (required);
+}

--- a/butte-examples/tests/array.rs
+++ b/butte-examples/tests/array.rs
@@ -1,0 +1,111 @@
+//! Test for https://github.com/butte-rs/butte/issues/39
+
+pub mod tests {
+    butte_build::include_fbs!("array");
+}
+
+use anyhow::{anyhow, Result};
+use butte as fb;
+use tests::array;
+
+#[test]
+fn test_table_array() -> Result<()> {
+    let mut builder = fb::FlatBufferBuilder::new();
+
+    // Create a flatbuffers table that holds arrays.
+    let mut table_entry_vec = vec![];
+    let mut enum_entry_vec = vec![];
+    let mut int_entry_vec = vec![];
+
+    for i in 0..2 {
+        let entry = array::Entry::create(&mut builder, &array::EntryArgs { value: i as u64 });
+        table_entry_vec.push(entry);
+        enum_entry_vec.push(array::Value::A);
+        int_entry_vec.push(i);
+    }
+
+    let table_entries = Some(builder.create_vector(&table_entry_vec));
+    let enum_entries = Some(builder.create_vector(&enum_entry_vec));
+    let int_entries = Some(builder.create_vector(&int_entry_vec));
+
+    let input = array::ArrayTable::create(
+        &mut builder,
+        &array::ArrayTableArgs {
+            table_entries,
+            enum_entries,
+            int_entries,
+        },
+    );
+
+    // Serialize.
+    builder.finish_minimal(input);
+    let raw_bytes = builder.finished_data();
+
+    // Deserialize and verify the result.
+    let output = array::ArrayTable::get_root(raw_bytes)?;
+    let table_entries = output
+        .table_entries()?
+        .ok_or_else(|| anyhow!("empty table_entries"))?;
+    let enum_entries = output
+        .table_entries()?
+        .ok_or_else(|| anyhow!("empty enum_entries"))?;
+    let int_entries = output
+        .table_entries()?
+        .ok_or_else(|| anyhow!("empty int_entries"))?;
+    assert_eq!(table_entries.len()?, table_entry_vec.len());
+    assert_eq!(enum_entries.len()?, enum_entry_vec.len());
+    assert_eq!(int_entries.len()?, int_entry_vec.len());
+
+    // Verify the table entry contents.
+    for (i, entry) in table_entries.iter().enumerate() {
+        assert_eq!(Some(i as u64), entry?.value()?);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_table_array_of_array() -> Result<()> {
+    let mut builder = fb::FlatBufferBuilder::new();
+
+    // Create a flatbuffers table that holds arrays of arrays.
+    let mut table_array_vec = vec![];
+
+    for _ in 0..2 {
+        let mut table_entry_vec = vec![];
+
+        for i in 0..2 {
+            let entry = array::Entry::create(&mut builder, &array::EntryArgs { value: i as u64 });
+            table_entry_vec.push(entry);
+        }
+
+        let table_entries = builder.create_vector(&table_entry_vec);
+
+        table_array_vec.push(table_entries);
+    }
+
+    let table_arrays = builder.create_vector(&table_array_vec);
+
+    let input = array::ArrayOfArrayTable::create(
+        &mut builder,
+        &array::ArrayOfArrayTableArgs { table_arrays },
+    );
+
+    // Serialize.
+    builder.finish_minimal(input);
+    let raw_bytes = builder.finished_data();
+
+    // Deserialize and verify the result.
+    let output = array::ArrayOfArrayTable::get_root(raw_bytes)?;
+    let table_arrays = output.table_arrays()?;
+    assert_eq!(table_arrays.len()?, table_array_vec.len());
+
+    // Verify the table entry contents.
+    for array in table_arrays.iter() {
+        for (i, entry) in array?.iter().enumerate() {
+            assert_eq!(Some(i as u64), entry?.value()?);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR addresses issue #39.

For array, the current code generates `WIPOffset<Vector<'a, WIPOffset` repeating the internal wrapper for the Vector-internal wrapper. I think the internal Vector-wrapper should always be `ForwardsUOffset`.

I didn't add arrays of unions as they aren't supported by `flatc`'s Rust mode and because I have a different issue that I'm still investigating.