### PR TITLE
Convert namespace to snake_case, fixes issue #50

### DIFF
--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -1006,7 +1006,7 @@ impl<'a> CodeGenerator<'a> {
             ir::Node::Enum(e) => e.to_tokens(tokens),
             ir::Node::Union(u) => u.to_tokens(tokens),
             ir::Node::Namespace(n) => {
-                let ident = &n.ident.simple();
+                let ident = format_ident!("{}", n.ident.simple().as_ref().to_snake_case());
                 let mut nodes_ts = TokenStream::default();
                 for node in &n.nodes {
                     self.node_to_tokens(node, rpc_gen, &mut nodes_ts);

--- a/butte-examples/fbs/greeter/greeter.fbs
+++ b/butte-examples/fbs/greeter/greeter.fbs
@@ -1,6 +1,6 @@
 /// A response from the server
 /// Useful for getting a greeting back!
-namespace foo.bar;
+namespace Foo.Bar;
 
 
 /// Hello there!
@@ -35,7 +35,7 @@ table HelloRequestArray {
   requests: [HelloRequest];
 }
 
-namespace baz.buzz;
+namespace Baz.Buzz;
 
 /// Doc
 enum Foo : int32 {
@@ -58,7 +58,7 @@ table FooBar {
 /// ... with a multiline doc comment?!
 rpc_service Greeter {
   /// More info
-  SayHello(foo.bar.HelloRequest) : foo.bar.HelloReply;
+  SayHello(Foo.Bar.HelloRequest) : Foo.Bar.HelloReply;
   /// Even more info
-  SayManyHellos(foo.bar.ManyHellosRequest) : foo.bar.HelloReply (streaming: "server");
+  SayManyHellos(Foo.Bar.ManyHellosRequest) : Foo.Bar.HelloReply (streaming: "server");
 }


### PR DESCRIPTION
This allows to use existing `.fbs` definitions that follow the official style of using `UpperCamelCase` for namespaces. Existing lower-case or snake_case namespaces are still supported with this PR.

See #50 