### PR TITLE
Derive implicit default value for scalar types

### DIFF
--- a/butte-build/src/ast/types.rs
+++ b/butte-build/src/ast/types.rs
@@ -1,6 +1,6 @@
 //! Types representing the parts of a flatbuffer schema
 use derive_more::{AsRef, From};
-use std::{collections::HashMap, iter::FromIterator, path::Path};
+use std::{collections::HashMap, convert::TryFrom, iter::FromIterator, path::Path};
 use typed_builder::TypedBuilder;
 
 /// A Flatbuffer schema.
@@ -389,6 +389,20 @@ impl From<BooleanConstant> for DefaultValue<'_> {
 impl<'a> From<&'a str> for DefaultValue<'a> {
     fn from(value: &'a str) -> Self {
         Ident::from(value).into()
+    }
+}
+
+impl<'a> TryFrom<&Type<'a>> for DefaultValue<'a> {
+    type Error = butte::Error;
+
+    fn try_from(ty: &Type<'a>) -> Result<Self, Self::Error> {
+        match ty {
+            Type::Array(..) | Type::Ident(..) | Type::String => None,
+            Type::Bool => Some(false.into()),
+            Type::Double | Type::Float | Type::Float32 | Type::Float64 => Some((0.0).into()),
+            _ => Some(0.into()),
+        }
+        .ok_or(butte::Error::NoTypeDefaultValue)
     }
 }
 

--- a/butte-build/src/ir/transform.rs
+++ b/butte-build/src/ir/transform.rs
@@ -4,7 +4,7 @@ use heck::SnakeCase;
 use itertools::Itertools;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
 };
 
 #[derive(Default, Clone, Debug)]
@@ -132,7 +132,8 @@ impl<'a> Builder<'a> {
                     });
                 }
                 let ident = ir::Ident::from(&f.id);
-                let default_value = f.default_value.clone();
+                // Use `Some` explicit or implicit default value or `None`
+                let default_value = f.default_value.clone().or_else(|| (&f.ty).try_into().ok());
                 let metadata = ir::FieldMetadata::builder().required(required).build();
                 let doc = f.doc.clone();
 

--- a/butte-examples/build.rs
+++ b/butte-examples/build.rs
@@ -1,7 +1,11 @@
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    for fbs in &["fbs/array.fbs", "fbs/greeter/greeter.fbs"] {
+    for fbs in &[
+        "fbs/array.fbs",
+        "fbs/default_value.fbs",
+        "fbs/greeter/greeter.fbs",
+    ] {
         butte_build::compile_fbs(fbs)?;
     }
     Ok(())

--- a/butte-examples/fbs/default_value.fbs
+++ b/butte-examples/fbs/default_value.fbs
@@ -1,0 +1,21 @@
+namespace DefaultValue;
+
+table Values {
+  bool_implicit: bool;
+  bool_explicit: bool = false;
+  bool_other: bool = true;
+
+  float_implicit: float;
+  float_explicit: float = 0;
+  float_other: float = 1;
+
+  int_implicit: int;
+  int_explicit: int = 0;
+  int_other: int = 1;
+
+  long_implicit: long;
+  long_explicit: long = 0;
+  long_other: long = 1;
+
+  text: string;
+}

--- a/butte-examples/tests/default_value.rs
+++ b/butte-examples/tests/default_value.rs
@@ -1,0 +1,42 @@
+pub mod tests {
+    butte_build::include_fbs!("default_value");
+}
+
+use anyhow::Result;
+use butte as fb;
+use tests::default_value;
+
+#[test]
+fn test_default_value() -> Result<()> {
+    let mut builder = fb::FlatBufferBuilder::new();
+
+    let input = default_value::Values::create(
+        &mut builder,
+        &default_value::ValuesArgs {
+            ..Default::default()
+        },
+    );
+
+    // Serialize.
+    builder.finish_minimal(input);
+    let raw_bytes = builder.finished_data();
+
+    // Deserialize and verify the result.
+    let output = default_value::Values::get_root(raw_bytes)?;
+
+    // Test if the implicit and explicit default value of zero match
+    // and are non-equal to the explicit non-zero default value.
+    assert_eq!(output.bool_implicit()?, output.bool_explicit()?);
+    assert_ne!(output.bool_implicit()?, output.bool_other()?);
+    assert_eq!(output.float_implicit()?, output.float_explicit()?);
+    assert_ne!(output.float_implicit()?, output.float_other()?);
+    assert_eq!(output.int_implicit()?, output.int_explicit()?);
+    assert_ne!(output.int_implicit()?, output.int_other()?);
+    assert_eq!(output.long_implicit()?, output.long_explicit()?);
+    assert_ne!(output.long_implicit()?, output.long_other()?);
+
+    // Strings don't have a default value.
+    assert_eq!(output.text()?, None);
+
+    Ok(())
+}

--- a/butte/src/error.rs
+++ b/butte/src/error.rs
@@ -11,10 +11,12 @@ pub enum Error {
     RequiredFieldMissing(&'static str),
     /// Returned if a string is not null-terminated,
     NonNullTerminatedString,
-    // Returned if a buffer refers to an unknown enum variant
+    /// Returned if a buffer refers to an unknown enum variant
     UnknownEnumVariant,
-    // Returned if a buffer refers to an unknown union variant
+    /// Returned if a buffer refers to an unknown union variant
     UnknownUnionVariant,
+    /// Returned if a type doesn't have a default value
+    NoTypeDefaultValue,
 }
 
 impl fmt::Display for Error {
@@ -26,6 +28,7 @@ impl fmt::Display for Error {
             Error::NonNullTerminatedString => write!(f, "string is not terminated with null"),
             Error::UnknownEnumVariant => write!(f, "unknown enum variant"),
             Error::UnknownUnionVariant => write!(f, "unknown union variant"),
+            Error::NoTypeDefaultValue => write!(f, "type does not have a default value"),
         }
     }
 }


### PR DESCRIPTION
This PR attempts to fix #62:

> Flatbuffers uses implicit default values for scalars. So all integers, floats, bools, or similar have an implicit default value of 0 or false. This is currently not done by butte. This also breaks compatibility with flatc as we fail to decode messages with default scalars: the field is not present in the buffer and we don't recognize it as a default value.

