### PR TITLE
Cleanup the read me a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Rust-native Flatbuffers
 
-[![Actions Status](https://github.com/butte-rs/butte/workflows/Butte/badge.svg)](https://github.com/butte-rs/butte/actions)
-[![Coverage Status](https://coveralls.io/repos/github/butte-rs/butte/badge.svg?branch=master)](https://coveralls.io/github/butte-rs/butte?branch=master)
+* [![Actions Status](https://github.com/butte-rs/butte/workflows/Butte/badge.svg)](https://github.com/butte-rs/butte/actions)
+  * ![Continuous Integration](https://github.com/butte-rs/butte/workflows/Continuous%20Integration/badge.svg)
+  * ![Security audit](https://github.com/butte-rs/butte/workflows/Security%20audit/badge.svg)


### PR DESCRIPTION
Removes the coverage badge and gives a breakdown of the actions being executed during a CI run