### PR TITLE
Move include_fbs from butte_build to butte.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.41.0  # MSRV
+          - 1.42.0  # MSRV
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/butte-build/src/ast/types.rs
+++ b/butte-build/src/ast/types.rs
@@ -261,10 +261,7 @@ impl Type<'_> {
         // TODO: enums are scalars, tables are not -- what about structs?
         // we might need more context to determine if the type is a scalar
         // to catch errors early
-        match self {
-            Type::String | Type::Array(_) => false,
-            _ => true,
-        }
+        !matches!(self, Type::String | Type::Array(_))
     }
 }
 

--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -421,7 +421,7 @@ impl ToTokens for ir::Table<'_> {
                 };
 
                 // Scalar or enum fields can have a default value
-                let default_doc = to_default_value_doc(&ty, default_value);
+                let default_doc = to_default_value_doc(ty, default_value);
                 quote! {
                     #default_doc
                     #allow_type_complexity
@@ -537,7 +537,7 @@ impl ToTokens for ir::Table<'_> {
 
             let body = if ty.is_scalar() {
                 if let Some(default_value) = default_value {
-                    let default_value = to_default_value(&arg_ty, &default_value);
+                    let default_value = to_default_value(&arg_ty, default_value);
                     quote!(self.fbb.push_slot::<#arg_ty>(#field_offset, #field_id, #default_value))
                 } else {
                     quote!(self.fbb.push_slot_always::<#arg_ty>(#field_offset, #field_id))
@@ -590,7 +590,7 @@ impl ToTokens for ir::Table<'_> {
                 true,
             );
             let default_value = if let Some(default_value) = default_value {
-                let default_value = to_default_value(&ty_wrapped, &default_value);
+                let default_value = to_default_value(&ty_wrapped, default_value);
                 quote!(Some(#default_value))
             } else {
                 quote!(None)

--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -635,7 +635,7 @@ impl ToTokens for ir::Table<'_> {
                             quote! {
                                 #enum_ident::#variant_ident => #union_ident::#variant_ident(self.table
                                     .get::<#variant_ty_wrapped>(#struct_id::#offset_name, None)?
-                                    .ok_or_else(|| butte::Error::RequiredFieldMissing(#snake_name_str))?)
+                                    .ok_or(butte::Error::RequiredFieldMissing(#snake_name_str))?)
                             }
                         },
                     );
@@ -685,9 +685,9 @@ impl ToTokens for ir::Table<'_> {
                     #[inline]
                     #allow_type_complexity
                     pub fn #snake_name(&self) -> Result<#ty_ret, butte::Error> {
-                        Ok(self.table
+                        self.table
                             .get::<#ty_wrapped>(#struct_id::#offset_name, #default_value)?
-                            .ok_or_else(|| butte::Error::RequiredFieldMissing(#snake_name_str))?)
+                            .ok_or(butte::Error::RequiredFieldMissing(#snake_name_str))
                     }
                 }
             } else {

--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -604,15 +604,12 @@ impl ToTokens for ir::Table<'_> {
             if ty.is_union() {
                 let (union_ident, enum_ident, variants) = match ty {
                     ir::Type::Custom(ir::CustomTypeRef {
-                        ty,
-                        ident: ref union_ident,
-                    }) => match ty {
-                        ir::CustomType::Union {
+                        ty: ir::CustomType::Union {
                             ref variants,
                             ref enum_ident,
-                        } => (union_ident, enum_ident, variants),
-                        _ => panic!("type is union"),
-                    },
+                        },
+                        ident: ref union_ident,
+                    }) => (union_ident, enum_ident, variants),
                     _ => panic!("type is union"),
                 };
 

--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -263,7 +263,7 @@ mod to_default_value_tests {
                 let value = ast::DefaultValue::Scalar($kind(rust_value));
                 let ty =
                     to_type_token(None, &ir::Type::$butte_ir_type, &quote!(), &quote!(), false);
-                let result = to_default_value(&ty, &value).to_string();
+                let result = to_default_value(&ty, &value).to_string().replace("- ", "-");
                 let expected = format!("{}{}", raw_value, stringify!($rust_type));
                 assert_eq!(result, expected);
             }
@@ -275,7 +275,10 @@ mod to_default_value_tests {
                 let value = ast::DefaultValue::Scalar($kind(rust_value));
                 let ty =
                     to_type_token(None, &ir::Type::$butte_ir_type, &quote!(), &quote!(), false);
-                let result = to_default_value(&ty, &value).to_string();
+                // Hack: there is no control to make TokenStream::ToString() print tokens without
+                // spaces in between (except running `cargo fmt`), so we're doing replace at the
+                // end to get properly formatted string (e.g. `- 123` -> `-123`).
+                let result = to_default_value(&ty, &value).to_string().replace("- ", "-");
                 let expected = format!("{}{}", raw_value, stringify!($rust_type));
                 assert_eq!(result, expected);
             }

--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -226,6 +226,7 @@ fn to_default_value_doc(
     ty: &ir::Type<'_>,
     default_value: &Option<ast::DefaultValue<'_>>,
 ) -> impl ToTokens {
+    #[allow(clippy::redundant_closure)] // Ignore this warning because quote!() is macro.
     default_value.as_ref().map_or_else(
         || quote!(),
         |default_value| {

--- a/butte-build/src/ir/transform.rs
+++ b/butte-build/src/ir/transform.rs
@@ -374,7 +374,7 @@ impl<'a> Builder<'a> {
     }
 
     fn new_root_ident(&mut self, ident: &ir::QualifiedIdent<'a>) -> Result<bool> {
-        if let Some(&CustomTypeStatus::Defined(ref def)) = self.types.get(&ident) {
+        if let Some(&CustomTypeStatus::Defined(ref def)) = self.types.get(ident) {
             if def == &ir::CustomType::Table {
                 self.root_types.insert(ident.clone());
                 Ok(true)
@@ -509,7 +509,7 @@ impl<'a> Builder<'a> {
                 }
             }
             ast::Type::Ident(qualified_ident) => {
-                let ident = self.make_fully_qualified_from_ast_qualified_ident(&qualified_ident);
+                let ident = self.make_fully_qualified_from_ast_qualified_ident(qualified_ident);
 
                 return self.find_custom_type(ident);
             }

--- a/butte-build/src/ir/transform.rs
+++ b/butte-build/src/ir/transform.rs
@@ -107,10 +107,7 @@ impl<'a> Builder<'a> {
             let ty = self.try_type(&f.ty);
             if let Some(ty) = ty {
                 let required = match &f.metadata {
-                    Some(m) => match m.values.get(&ast::Ident::from("required")) {
-                        Some(None) => true,
-                        _ => false,
-                    },
+                    Some(m) => matches!(m.values.get(&ast::Ident::from("required")), Some(None)),
                     None => false,
                 };
 
@@ -596,7 +593,7 @@ impl<'a> Builder<'a> {
             .into_iter()
             .collect();
 
-        let namespaces_idents: BTreeSet<_> = elements.keys().cloned().filter_map(|id| id).collect();
+        let namespaces_idents: BTreeSet<_> = elements.keys().cloned().flatten().collect();
 
         let mut namespaces: Vec<_> = namespaces_idents
             .into_iter()

--- a/butte-build/src/ir/types.rs
+++ b/butte-build/src/ir/types.rs
@@ -180,30 +180,27 @@ impl<'a> Type<'a> {
     }
 
     pub fn is_union(&self) -> bool {
-        match self {
-            Type::Custom(CustomTypeRef { ty, .. }) => match ty {
-                CustomType::Union { .. } => true,
-                _ => false,
-            },
-            _ => false,
-        }
+        matches!(
+            self,
+            Type::Custom(CustomTypeRef {
+                ty: CustomType::Union { .. },
+                ..
+            })
+        )
     }
 
     pub fn is_enum(&self) -> bool {
-        match self {
-            Type::Custom(CustomTypeRef { ty, .. }) => match ty {
-                CustomType::Enum { .. } => true,
-                _ => false,
-            },
-            _ => false,
-        }
+        matches!(
+            self,
+            Type::Custom(CustomTypeRef {
+                ty: CustomType::Enum { .. },
+                ..
+            })
+        )
     }
 
     pub fn is_array(&self) -> bool {
-        match self {
-            Type::Array(..) => true,
-            _ => false,
-        }
+        matches!(self, Type::Array(..))
     }
 
     // Is it a complex type that will trigger Clippy warnings
@@ -217,10 +214,10 @@ impl<'a> Type<'a> {
     // This method lets us generate the companion type name from the union.
     pub fn make_union_enum_type_companion(&self) -> Option<&QualifiedIdent<'a>> {
         match self {
-            Type::Custom(CustomTypeRef { ty, .. }) => match ty {
-                CustomType::Union { ref enum_ident, .. } => Some(enum_ident),
-                _ => None,
-            },
+            Type::Custom(CustomTypeRef {
+                ty: CustomType::Union { ref enum_ident, .. },
+                ..
+            }) => Some(enum_ident),
             _ => None,
         }
     }
@@ -281,10 +278,7 @@ pub enum CustomType<'a> {
 
 impl<'a> CustomType<'a> {
     pub fn is_scalar(&self) -> bool {
-        match self {
-            CustomType::Struct { .. } | CustomType::Enum { .. } => true,
-            _ => false,
-        }
+        matches!(self, CustomType::Struct { .. } | CustomType::Enum { .. })
     }
 }
 

--- a/butte-build/src/lib.rs
+++ b/butte-build/src/lib.rs
@@ -1,8 +1,6 @@
 pub mod codegen;
 mod compile;
 
-mod macros;
-
 pub mod ast;
 pub mod ir;
 

--- a/butte-examples/Cargo.toml
+++ b/butte-examples/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/greeter/greeter.rs"
 
 [dependencies]
 anyhow = "1.0.26"
-butte-build = { path = "../butte-build" }
 butte = { path = "../butte" }
 
 [build-dependencies]

--- a/butte-examples/src/greeter/greeter.rs
+++ b/butte-examples/src/greeter/greeter.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use butte as fb;
 
 pub mod greeter {
-    butte_build::include_fbs!("greeter");
+    butte::include_fbs!("greeter");
 }
 
 fn main() -> Result<()> {

--- a/butte-examples/tests/array.rs
+++ b/butte-examples/tests/array.rs
@@ -1,7 +1,7 @@
 //! Test for https://github.com/butte-rs/butte/issues/39
 
 pub mod tests {
-    butte_build::include_fbs!("array");
+    butte::include_fbs!("array");
 }
 
 use anyhow::{anyhow, Result};

--- a/butte-examples/tests/default_value.rs
+++ b/butte-examples/tests/default_value.rs
@@ -1,5 +1,5 @@
 pub mod tests {
-    butte_build::include_fbs!("default_value");
+    butte::include_fbs!("default_value");
 }
 
 use anyhow::Result;

--- a/butte/src/builder.rs
+++ b/butte/src/builder.rs
@@ -406,7 +406,7 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
         // Write the vtable offset, which is the start of any Table.
         // We fill its value later.
         let object_revloc_to_vtable: WIPOffset<VTableWIPOffset> =
-            WIPOffset::new(self.push::<UOffsetT>(0xF0F0_F0F0 as UOffsetT).value());
+            WIPOffset::new(self.push::<UOffsetT>(0xF0F0_F0F0).value());
 
         // Layout of the data this function will create when a new vtable is
         // needed.

--- a/butte/src/builder.rs
+++ b/butte/src/builder.rs
@@ -656,23 +656,21 @@ impl<'fbb> FlatBufferBuilder<'fbb> {
         // could be empty (e.g. for empty tables, or for all-default values).
         debug_assert!(
             self.nested,
-            format!(
-                "incorrect FlatBufferBuilder usage: {} must be called while in a nested state",
-                fn_name
-            )
+            "incorrect FlatBufferBuilder usage: {} must be called while in a nested state",
+            fn_name
         );
     }
     #[inline]
     fn assert_not_nested(&self, msg: &'static str) {
-        debug_assert!(!self.nested, msg);
+        debug_assert!(!self.nested, "{}", msg);
     }
     #[inline]
     fn assert_finished(&self, msg: &'static str) {
-        debug_assert!(self.finished, msg);
+        debug_assert!(self.finished, "{}", msg);
     }
     #[inline]
     fn assert_not_finished(&self, msg: &'static str) {
-        debug_assert!(!self.finished, msg);
+        debug_assert!(!self.finished, "{}", msg);
     }
 }
 

--- a/butte/src/endian_scalar.rs
+++ b/butte/src/endian_scalar.rs
@@ -30,6 +30,7 @@ use std::mem::size_of;
 /// invalid FlatBuffers type.
 pub trait EndianScalar: Sized + PartialEq + Copy + Clone {
     fn to_little_endian(self) -> Self;
+    #[allow(clippy::wrong_self_convention)]
     fn from_little_endian(self) -> Self;
 }
 

--- a/butte/src/endian_scalar.rs
+++ b/butte/src/endian_scalar.rs
@@ -175,7 +175,7 @@ pub fn read_scalar_at<T: EndianScalar>(s: &[u8], loc: usize) -> Result<T, Error>
 pub fn read_scalar<T: EndianScalar>(s: &[u8]) -> Result<T, Error> {
     let sz = size_of::<T>();
 
-    let p = (&s.get(..sz).ok_or(Error::OutOfBounds)?).as_ptr() as *const T;
+    let p = s.get(..sz).ok_or(Error::OutOfBounds)?.as_ptr() as *const T;
     let x = unsafe { *p };
 
     Ok(x.from_little_endian())

--- a/butte/src/lib.rs
+++ b/butte/src/lib.rs
@@ -33,6 +33,7 @@ mod builder;
 mod endian_scalar;
 mod error;
 mod follow;
+mod macros;
 mod primitives;
 mod push;
 mod table;

--- a/butte/src/macros.rs
+++ b/butte/src/macros.rs
@@ -5,7 +5,7 @@
 /// ```ignore
 /// # // This doesn't compile, because OUT_DIR isn't set
 /// mod greeter {
-///     butte_build::include_fbs!("greeter");
+///     butte::include_fbs!("greeter");
 /// }
 /// ```
 #[macro_export]

--- a/butte/src/table.rs
+++ b/butte/src/table.rs
@@ -40,11 +40,11 @@ where
     B: std::convert::AsRef<[u8]>,
 {
     pub fn get_root(buf: B) -> Result<Self, Error> {
-        Ok(<ForwardsUOffset<Self>>::follow_buf(buf, 0)?)
+        <ForwardsUOffset<Self>>::follow_buf(buf, 0)
     }
 
     pub fn get_size_prefixed_root(buf: B) -> Result<Self, Error> {
-        Ok(<SkipSizePrefix<ForwardsUOffset<Self>>>::follow_buf(buf, 0)?)
+        <SkipSizePrefix<ForwardsUOffset<Self>>>::follow_buf(buf, 0)
     }
 
     pub fn vtable<'a>(&'a self) -> Result<VTable<'a>, Error> {

--- a/butte/src/vector.rs
+++ b/butte/src/vector.rs
@@ -55,7 +55,7 @@ impl<'a, T: 'a> Vector<'a, T> {
     #[allow(clippy::len_without_is_empty)]
     #[inline(always)]
     pub fn len(&self) -> Result<usize, Error> {
-        Ok(read_scalar_at::<UOffsetT>(&self.0, self.1)? as usize)
+        Ok(read_scalar_at::<UOffsetT>(self.0, self.1)? as usize)
     }
     #[inline(always)]
     pub fn is_empty(&self) -> Result<bool, Error> {
@@ -66,7 +66,7 @@ impl<'a, T: 'a> Vector<'a, T> {
 impl<'a, T: Follow<'a> + 'a> Vector<'a, T> {
     #[inline(always)]
     pub fn get(&self, idx: usize) -> Result<T::Inner, Error> {
-        debug_assert!(idx < read_scalar_at::<u32>(&self.0, self.1)? as usize);
+        debug_assert!(idx < read_scalar_at::<u32>(self.0, self.1)? as usize);
         let sz = size_of::<T>();
         debug_assert!(sz > 0);
         T::follow(self.0, self.1 as usize + SIZE_UOFFSET + sz * idx)
@@ -88,7 +88,7 @@ impl<'a, T: SafeSliceAccess + 'a> Vector<'a, T> {
         let loc = self.1;
         let sz = size_of::<T>();
         debug_assert!(sz > 0);
-        let len = read_scalar_at::<UOffsetT>(&buf, loc)? as usize;
+        let len = read_scalar_at::<UOffsetT>(buf, loc)? as usize;
         let data_buf = buf
             .get(loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len * sz)
             .ok_or(Error::OutOfBounds)?;
@@ -138,7 +138,7 @@ impl<'a> Follow<'a> for &'a str {
     type Inner = &'a str;
     fn follow(buf: &'a [u8], loc: usize) -> Result<Self::Inner, Error> {
         // Len of the String/Vector
-        let len = read_scalar_at::<UOffsetT>(&buf, loc)? as usize;
+        let len = read_scalar_at::<UOffsetT>(buf, loc)? as usize;
 
         let end_loc = loc + SIZE_UOFFSET + len;
 
@@ -164,7 +164,7 @@ impl<'a> Follow<'a> for &'a str {
 fn follow_slice_helper<T>(buf: &[u8], loc: usize) -> Result<&[T], Error> {
     let sz = size_of::<T>();
     debug_assert!(sz > 0);
-    let len = read_scalar_at::<UOffsetT>(&buf, loc)? as usize;
+    let len = read_scalar_at::<UOffsetT>(buf, loc)? as usize;
     let data_buf = buf
         .get(loc + SIZE_UOFFSET..loc + SIZE_UOFFSET + len * sz)
         .ok_or(Error::OutOfBounds)?;

--- a/butte/src/vector.rs
+++ b/butte/src/vector.rs
@@ -52,6 +52,7 @@ impl<'a, T: 'a> Vector<'a, T> {
         }
     }
 
+    #[allow(clippy::len_without_is_empty)]
     #[inline(always)]
     pub fn len(&self) -> Result<usize, Error> {
         Ok(read_scalar_at::<UOffsetT>(&self.0, self.1)? as usize)

--- a/butte/src/vtable_writer.rs
+++ b/butte/src/vtable_writer.rs
@@ -60,7 +60,7 @@ impl<'a> VTableWriter<'a> {
     #[inline(always)]
     pub fn get_field_offset(&self, vtable_offset: VOffsetT) -> VOffsetT {
         let idx = vtable_offset as usize;
-        read_scalar_at::<VOffsetT>(&self.buf, idx).expect("Could not read scalar")
+        read_scalar_at::<VOffsetT>(self.buf, idx).expect("Could not read scalar")
     }
 
     /// Writes an object field offset into the vtable.


### PR DESCRIPTION
Typically `butte-build` crate is expected to be referenced at build time to
generate code. However in current implementation it needs to be
referenced at runtime as well in order to use `include_fbs` macro.
This PR moves `include_fbs` macro to `butte` crate, so no extra dependency
will be required.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>