### PR TITLE
A few minor fixes

### DIFF
--- a/butte-build/src/codegen.rs
+++ b/butte-build/src/codegen.rs
@@ -707,8 +707,6 @@ impl ToTokens for ir::Table<'_> {
             }
         });
 
-        let struct_offset_enum_name = format_ident!("{}Offset", raw_struct_name);
-
         let required_fields = fields
             .iter()
             .filter(|field| field.metadata.required)
@@ -721,8 +719,6 @@ impl ToTokens for ir::Table<'_> {
             });
 
         (quote! {
-            pub enum #struct_offset_enum_name {}
-
             #[derive(Copy, Clone, Debug, PartialEq)]
             #doc
             pub struct #struct_id<B> {

--- a/butte/src/lib.rs
+++ b/butte/src/lib.rs
@@ -51,7 +51,7 @@ pub use crate::{
     primitives::*,
     push::Push,
     table::{buffer_has_identifier, get_root, get_size_prefixed_root, Table},
-    vector::{follow_cast_ref, SafeSliceAccess, Vector},
+    vector::{follow_cast_ref, SafeSliceAccess, Vector, VectorIter},
     vtable::field_index_to_field_offset,
 };
 


### PR DESCRIPTION
- https://github.com/butte-rs/butte/commit/3636d92e7dab9f58b890f7636e2f3a3d101b8e87 Removes `enum NameOffset {}` enums from generated code. This seems to be not used anywhere, but the compiler complains with unused enum items.
-  https://github.com/butte-rs/butte/commit/cb8cd15ae724b419b906604ebea2ce2ef05da393 Re-exports `VectorIter` for convenience, to make it easier return from a function/wrap etc.